### PR TITLE
Fix permissions merging in top level AndroidManifest.xml

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -3,4 +3,7 @@
           package="burrows.apps.example.template">
 
     <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="${targetSdkVersion}" />
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>


### PR DESCRIPTION
Bazel does not merge permissions from android_library dependencies for security reasons, so we add the required permissions here.