### PR TITLE
Fix manifest on Android 12

### DIFF
--- a/src/main/java/AndroidManifest.xml
+++ b/src/main/java/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity
             android:name=".activity.MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"
+            android:exported="true"
             android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
Android 12 requires `exported` to be set on launcher activities

```
stderr: adb: failed to install ./bazel-out/k8-fastbuild/bin/src/main/template_app_incremental.apk: Failure 
[INSTALL_PARSE_FAILED_MANIFEST_MALFORMED: Failed parse during installPackageLI: /data/app/v9.tmp/base.apk (at Binary XML file line #18): burrows.apps.example.template.activity.MainActivity: 
Targeting S+ (version 31 and above) requires that an explicit value for android:exported be defined when intent filters are present]
Target //src/main:template_app failed to build
```

![Screenshot from 2022-07-25 15-14-50](https://user-images.githubusercontent.com/6628497/180856883-5e8c123d-bc1f-47da-8fc6-f31618fbeb89.png)
